### PR TITLE
Add support for USB/RS485 cable ID 1a86:55d3 QinHeng Electronics.

### DIFF
--- a/SolarTracer.py
+++ b/SolarTracer.py
@@ -37,6 +37,8 @@ DCkwhTotal = 0x330A
 PVkwhToday = 0x330C
 DCkwhToday = 0x3304
 
+ControllerTemp = 0x3111
+
 # Settings
 BatteryType=0x9000
 BatteryCapacity=0x9001

--- a/logtracer_csv.py
+++ b/logtracer_csv.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+
+import sys
+import datetime
+import time
+import minimalmodbus
+from SolarTracer import *
+
+up = SolarTracer()
+if (up.connect() < 0):
+	print ("Could not connect to the device")
+	exit -2
+
+# get timestamps
+timestamp = datetime.datetime.utcnow()
+
+FloatNo = 0.0
+
+PVvolt = up.readReg(PVvolt) + FloatNo
+PVamps = up.readReg(PVamps) + FloatNo
+PVwatt = round(PVvolt * PVamps, 2)
+PVkwhTotal = up.readReg(PVkwhTotal);
+PVkwhToday = up.readReg(PVkwhToday);
+
+BAvolt = up.readReg(BAvolt)
+BAamps = up.readReg(BAamps) + FloatNo
+BAperc = up.readReg(BAperc) * 100
+BAtemp = up.readReg(BAtemp)
+
+ControllerTemp = up.readReg(ControllerTemp)
+
+DCvolt = up.readReg(DCvolt) + FloatNo
+DCamps = round(up.readReg(DCamps), 2) + FloatNo
+DCwatt = round(DCvolt * DCamps, 2) + FloatNo
+DCkwhTotal = up.readReg(DCkwhTotal)
+DCkwhToday = up.readReg(DCkwhToday)
+
+## form a data record
+#body_solar = [
+#    {
+#        "t": timestamp,
+#        "d": {
+#            # Solar panel
+#            "PVV": PVvolt,
+#            "PVI": PVamps,
+#            "PVW": PVwatt,
+#            "PVKWh": PVkwhTotal,
+#            "PVKWh24": PVkwhToday,
+#            # Battery
+#            "BV": BAvolt,
+#            "BI": BAamps,
+#            "BSOC": BAperc,
+#            "BTEMP": BAtemp,
+#            "CTEMP": ControllerTemp,
+#            # Load
+#            "LV": DCvolt,
+#            "LI": DCamps,
+#            "LW": DCwatt,
+#            "LKWh": DCkwhTotal,
+#            "LKWh24": DCkwhToday
+#        }
+#    }
+#]
+#print (body_solar)
+
+# print csv format
+print('%.3f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f\n' %
+        (timestamp.timestamp(),
+        PVvolt, PVamps, PVwatt, PVkwhTotal, PVkwhToday,
+        DCvolt, DCamps, DCwatt, DCkwhTotal, DCkwhToday,
+        BAvolt, BAamps, BAperc, BAtemp, ControllerTemp))
+
+
+

--- a/xr_usb_serial_common-1a-linux-3.6+/modules.order
+++ b/xr_usb_serial_common-1a-linux-3.6+/modules.order
@@ -1,1 +1,1 @@
-/home/pi/epever-upower-tracer/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.ko
+kernel//home/debian/src/epever-upower-tracer/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.ko

--- a/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.c
@@ -1677,6 +1677,7 @@ static const struct usb_device_id xr_usb_serial_ids[] = {
 	{ USB_DEVICE(0x04e2, 0x1401)},
 	{ USB_DEVICE(0x04e2, 0x1402)},
 	{ USB_DEVICE(0x04e2, 0x1403)},
+	{ USB_DEVICE(0x1a86, 0x55d3)},
 	{ }
 };
 


### PR DESCRIPTION
Manufacturer: EPEVER
Model: CC-USB-RS485-150U

Tested on old Beaglebone Green: 4.19.94-ti-r42 #1buster SMP PREEMPT Tue Mar 31 19:38:29 UTC 2020 armv7l GNU/Linux