### PR TITLE
Add support for USB/RS485 cable ID 1a86:55d3 QinHeng Electronics.  Add ControllerTemp register.

### DIFF
--- a/SolarTracer.py
+++ b/SolarTracer.py
@@ -37,6 +37,8 @@ DCkwhTotal = 0x330A
 PVkwhToday = 0x330C
 DCkwhToday = 0x3304
 
+ControllerTemp = 0x3111
+
 # Settings
 BatteryType=0x9000
 BatteryCapacity=0x9001

--- a/xr_usb_serial_common-1a-linux-3.6+/modules.order
+++ b/xr_usb_serial_common-1a-linux-3.6+/modules.order
@@ -1,1 +1,1 @@
-/home/pi/epever-upower-tracer/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.ko
+kernel//home/debian/src/epever-upower-tracer/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.ko

--- a/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a-linux-3.6+/xr_usb_serial_common.c
@@ -1677,6 +1677,7 @@ static const struct usb_device_id xr_usb_serial_ids[] = {
 	{ USB_DEVICE(0x04e2, 0x1401)},
 	{ USB_DEVICE(0x04e2, 0x1402)},
 	{ USB_DEVICE(0x04e2, 0x1403)},
+	{ USB_DEVICE(0x1a86, 0x55d3)},
 	{ }
 };
 


### PR DESCRIPTION
Manufacturer: EPEVER
Model: CC-USB-RS485-150U

Tested on old Beaglebone Green: 4.19.94-ti-r42 #1buster SMP PREEMPT Tue Mar 31 19:38:29 UTC 2020 armv7l GNU/Linux